### PR TITLE
Use alternative api for domain test

### DIFF
--- a/test/micro_ros_renesas_testbench/client_tests/Domain.c
+++ b/test/micro_ros_renesas_testbench/client_tests/Domain.c
@@ -36,15 +36,13 @@ void microros_app(void)
 
     //create init_options
     rclc_support_t support;
+    rclc_support_init(&support, 0, NULL, &allocator);
 
-    rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
-    rcl_init_options_init(&init_options, allocator);
-    rcl_init_options_set_domain_id(&init_options, DOMAIN_ID);
-    rclc_support_init_with_options(&support, 0, NULL, &init_options, &allocator);
-
-    // create node
-    rcl_node_t node;
-    rclc_node_init_default(&node, "test_node", "", &support);
+	// create node
+	rcl_node_t node;
+	rcl_node_options_t node_ops = rcl_node_get_default_options();
+	node_ops.domain_id = (size_t)(DOMAIN_ID);
+	rclc_node_init_with_options(&node, "test_node", "", &support, &node_ops);
 
     // create publisher
     rclc_publisher_init_default(


### PR DESCRIPTION
Test to check that the new domain id API is compatible with previous implementations.